### PR TITLE
entrypoint.sh no longer a build-arg

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,7 @@ ARG environment
 COPY ${environment} /usr/tmp/environment.yml
 RUN chown $UID:$GID /usr/tmp/environment.yml
 
-ARG entrypoint
-COPY ${entrypoint} /usr/local/bin/docker-entrypoint.sh
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chown $UID:$GID /usr/local/bin/docker-entrypoint.sh && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,6 @@ $ docker image build \
   --build-arg uid=$UID \
   --build-arg gid=$GID \
   --build-arg environment=environment.yml \
-  --build-arg entrypoint=docker/entrypoint.sh \
   --file Dockerfile \
   --tag $IMAGE_NAME:$IMAGE_TAG \
   ../

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,6 @@ services:
         - uid=${UID}
         - gid=${GID}
         - environment=environment.yml
-        - entrypoint=docker/entrypoint.sh
       context: ../
       dockerfile: docker/Dockerfile
     ports:

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -6,7 +6,6 @@ docker image build \
     --build-arg uid=1000 \
     --build-arg gid=100 \
     --build-arg environment=environment.yml \
-    --build-arg entrypoint=docker/entrypoint.sh \
     --tag "$DOCKER_REPO:latest" \
     --file Dockerfile \
     ../


### PR DESCRIPTION
The `docker/entrypoint.sh` script activates the Conda environment inside the container before anything else happens. Since this behavior is always desirable, I don't see why it should be a build arg for the Docker image.